### PR TITLE
CTDA-1109 Make the Notification class sealed

### DIFF
--- a/app/uk/gov/hmrc/pushpullnotificationreceiverstub/models/Notification.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationreceiverstub/models/Notification.scala
@@ -35,7 +35,7 @@ import scala.xml.NodeSeq
 
 import XMLFormats._
 
-trait Notification extends Product with Serializable {
+sealed abstract class Notification extends Product with Serializable {
   def notificationId: NotificationId
   def boxId: BoxId
   def status: NotificationStatus


### PR DESCRIPTION
This was an oversight in the original PR but should also have the cheeky side effect of creating a release now that the build job is defined in Jenkins 😄 